### PR TITLE
The main wiki server configuration is always used #10

### DIFF
--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/DiscoveryManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/DiscoveryManager.java
@@ -27,6 +27,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -53,7 +54,7 @@ import com.xwiki.collabora.configuration.CollaboraConfiguration;
 public class DiscoveryManager
 {
     @Inject
-    private CollaboraConfiguration configuration;
+    private Provider<CollaboraConfiguration> configurationProvider;
 
     /**
      * Get the urlSrc specific to this type of file. This is needed in order to know which part of Collabora online to
@@ -65,7 +66,8 @@ public class DiscoveryManager
      */
     public String getURLSrc(String fileId) throws IOException
     {
-        URL discoveryURL = this.configuration.getDiscoveryURL();
+        // Use a provider in order to not cache the configuration of a specific wiki.
+        URL discoveryURL = this.configurationProvider.get().getDiscoveryURL();
         HttpURLConnection connection = (HttpURLConnection) discoveryURL.openConnection();
         connection.setRequestMethod("GET");
 

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
@@ -99,7 +99,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
             return Response.status(Response.Status.OK).entity(message.toString()).type(MediaType.APPLICATION_JSON)
                 .build();
         } catch (Exception e) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -118,7 +118,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
             return Response.ok().entity(attachment.getContentInputStream(xcontext)).type(attachment.getMimeType())
                 .build();
         } catch (Exception e) {
-            return Response.status(Response.Status.NOT_FOUND).entity(e).build();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).build();
         }
     }
 
@@ -148,6 +148,11 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     public Token getToken(String fileId) throws XWikiRestException
     {
         XWikiContext xcontext = this.contextProvider.get();
+        // Make sure that the current wiki is used on the XWiki context, since the REST resource is rooted on the
+        // main wiki.
+        AttachmentReference attachmentReference = this.attachmentReferenceResolver.resolve(fileId);
+        xcontext.setWikiReference(attachmentReference.getDocumentReference().getWikiReference());
+
         try {
             String urlSrc = discoveryManager.getURLSrc(fileId);
 
@@ -157,7 +162,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
 
             return token;
         } catch (IOException e) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
 


### PR DESCRIPTION
* set on the xcontext the current wiki, since the rest resource will use by default the main wiki, where it is actually rooted
* use a provider for accessing the configuration, to not have it cached for a specific wiki
* update some HTTP response status code, to be semantically correct