### PR TITLE
Use the main wiki configuration in case other value is not set at subwiki level #5

### DIFF
--- a/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
@@ -49,6 +49,7 @@ public interface CollaboraConfiguration
      * level.
      *
      * @return {@code true} if Collabora is enabled, {@code false} when is disabled or not specified
+     * @since 1.1
      */
     boolean isEnabled();
 }

--- a/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
@@ -48,7 +48,7 @@ public interface CollaboraConfiguration
      * Check if Collabora is enabled. Fallback on the main wiki configuration in case it was not defined at the wiki
      * level.
      *
-     * @return {@code true} if Collabora is enabled, {@code false} if not, and {@code null} when no value is defined
+     * @return {@code true} if Collabora is enabled, {@code false} when is disabled or not specified
      */
-    Boolean isEnabled();
+    boolean isEnabled();
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/AbstractCollaboraConfigurationSource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/AbstractCollaboraConfigurationSource.java
@@ -19,38 +19,29 @@
  */
 package com.xwiki.collabora.internal.configuration;
 
-import javax.inject.Named;
+import java.util.Arrays;
+import java.util.List;
 
-import org.xwiki.component.annotation.Component;
-import org.xwiki.model.reference.DocumentReference;
-
-import groovy.lang.Singleton;
+import org.xwiki.configuration.internal.AbstractDocumentConfigurationSource;
+import org.xwiki.model.reference.LocalDocumentReference;
 
 /**
- * Collabora configuration source corresponding to the current wiki.
+ * Common features for all Collabora configuration sources.
  *
  * @version $Id$
- * @since 1.0
+ * @since 1.1
  */
-@Component
-@Named(CollaboraConfigurationSource.HINT)
-@Singleton
-public class CollaboraConfigurationSource extends AbstractCollaboraConfigurationSource
+public abstract class AbstractCollaboraConfigurationSource extends AbstractDocumentConfigurationSource
 {
-    /**
-     * The hint for this component.
-     */
-    public static final String HINT = "collabora.configuration.current";
+    private static final List<String> SPACE = Arrays.asList("Collabora", "Code");
+
+    protected static final LocalDocumentReference CONFIG_DOC = new LocalDocumentReference(SPACE, "Configuration");
+
+    private static final LocalDocumentReference CONFIG_CLASS = new LocalDocumentReference(SPACE, "ConfigurationClass");
 
     @Override
-    protected DocumentReference getDocumentReference()
+    protected LocalDocumentReference getClassReference()
     {
-        return new DocumentReference(AbstractCollaboraConfigurationSource.CONFIG_DOC, this.getCurrentWikiReference());
-    }
-
-    @Override
-    protected String getCacheId()
-    {
-        return HINT;
+        return CONFIG_CLASS;
     }
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/AbstractCollaboraConfigurationSource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/AbstractCollaboraConfigurationSource.java
@@ -26,7 +26,9 @@ import org.xwiki.configuration.internal.AbstractDocumentConfigurationSource;
 import org.xwiki.model.reference.LocalDocumentReference;
 
 /**
- * Common features for all Collabora configuration sources.
+ * Common features for all Collabora configuration sources. This class can be removed after upgrading to a XWiki parent
+ * >= 14.9, that introduces XWIKI-20195: Make it easy to implement a document-based configuration source that falls back
+ * on the main wiki.
  *
  * @version $Id$
  * @since 1.1

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -26,12 +26,11 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 
 import com.xwiki.collabora.configuration.CollaboraConfiguration;
-
-import liquibase.util.StringUtils;
 
 /**
  * Default implementation of {@link CollaboraConfiguration}.
@@ -43,6 +42,8 @@ import liquibase.util.StringUtils;
 @Singleton
 public class DefaultCollaboraConfiguration implements CollaboraConfiguration
 {
+    private static final String IS_ENABLED = "isEnabled";
+
     private static final String SERVER = "server";
 
     @Inject
@@ -57,18 +58,20 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     public URL getDiscoveryURL() throws MalformedURLException
     {
 
-        return new URL(getServerConfiguration() + "/hosting/discovery");
+        return new URL(this.getServer() + "/hosting/discovery");
     }
 
-    /**
-     * Fallback on the main wiki server configuration in case it was not defined at the wiki level.
-     *
-     * @return the Collabora Online server defined in configuration
-     */
-    private String getServerConfiguration()
+    @Override
+    public Boolean isEnabled()
+    {
+        Boolean isCurrentWikiEnabled = this.currentConfiguration.getProperty(IS_ENABLED, Boolean.class);
+        return isCurrentWikiEnabled == null ? this.mainConfiguration.getProperty(IS_ENABLED, Boolean.class)
+            : isCurrentWikiEnabled;
+    }
+
+    private String getServer()
     {
         String currentWikiServer = this.currentConfiguration.getProperty(SERVER);
-        String mainWikiServer = this.mainConfiguration.getProperty(SERVER);
-        return StringUtils.isEmpty(currentWikiServer) ? mainWikiServer : currentWikiServer;
+        return StringUtils.isEmpty(currentWikiServer) ? this.mainConfiguration.getProperty(SERVER) : currentWikiServer;
     }
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -31,6 +31,8 @@ import org.xwiki.configuration.ConfigurationSource;
 
 import com.xwiki.collabora.configuration.CollaboraConfiguration;
 
+import liquibase.util.StringUtils;
+
 /**
  * Default implementation of {@link CollaboraConfiguration}.
  *
@@ -41,13 +43,32 @@ import com.xwiki.collabora.configuration.CollaboraConfiguration;
 @Singleton
 public class DefaultCollaboraConfiguration implements CollaboraConfiguration
 {
+    private static final String SERVER = "server";
+
     @Inject
-    @Named("collabora")
-    private ConfigurationSource configuration;
+    @Named(MainCollaboraConfigurationSource.HINT)
+    private ConfigurationSource mainConfiguration;
+
+    @Inject
+    @Named(CollaboraConfigurationSource.HINT)
+    private ConfigurationSource currentConfiguration;
 
     @Override
     public URL getDiscoveryURL() throws MalformedURLException
     {
-        return new URL(this.configuration.getProperty("server") + "/hosting/discovery");
+
+        return new URL(getServerConfiguration() + "/hosting/discovery");
+    }
+
+    /**
+     * Fallback on the main wiki server configuration in case it was not defined at the wiki level.
+     *
+     * @return the Collabora Online server defined in configuration
+     */
+    private String getServerConfiguration()
+    {
+        String currentWikiServer = this.currentConfiguration.getProperty(SERVER);
+        String mainWikiServer = this.mainConfiguration.getProperty(SERVER);
+        return StringUtils.isEmpty(currentWikiServer) ? mainWikiServer : currentWikiServer;
     }
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -62,10 +62,10 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     }
 
     @Override
-    public Boolean isEnabled()
+    public boolean isEnabled()
     {
         Boolean isCurrentWikiEnabled = this.currentConfiguration.getProperty(IS_ENABLED, Boolean.class);
-        return isCurrentWikiEnabled == null ? this.mainConfiguration.getProperty(IS_ENABLED, Boolean.class)
+        return isCurrentWikiEnabled == null ? this.mainConfiguration.getProperty(IS_ENABLED, false)
             : isCurrentWikiEnabled;
     }
 

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -57,7 +57,6 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     @Override
     public URL getDiscoveryURL() throws MalformedURLException
     {
-
         return new URL(this.getServer() + "/hosting/discovery");
     }
 

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/MainCollaboraConfigurationSource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/MainCollaboraConfigurationSource.java
@@ -19,33 +19,40 @@
  */
 package com.xwiki.collabora.internal.configuration;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import groovy.lang.Singleton;
 
 /**
- * Collabora configuration source corresponding to the current wiki.
+ * Collabora configuration source corresponding to the main wiki.
  *
  * @version $Id$
- * @since 1.0
+ * @since 1.1
  */
 @Component
-@Named(CollaboraConfigurationSource.HINT)
+@Named(MainCollaboraConfigurationSource.HINT)
 @Singleton
-public class CollaboraConfigurationSource extends AbstractCollaboraConfigurationSource
+public class MainCollaboraConfigurationSource extends AbstractCollaboraConfigurationSource
 {
     /**
      * The hint for this component.
      */
-    public static final String HINT = "collabora.configuration.current";
+    public static final String HINT = "collabora.configuration.main";
+
+    @Inject
+    protected WikiDescriptorManager wikiManager;
 
     @Override
     protected DocumentReference getDocumentReference()
     {
-        return new DocumentReference(AbstractCollaboraConfigurationSource.CONFIG_DOC, this.getCurrentWikiReference());
+        return new DocumentReference(AbstractCollaboraConfigurationSource.CONFIG_DOC,
+            new WikiReference(this.wikiManager.getMainWikiId()));
     }
 
     @Override

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/script/CollaboraConfigurationScriptService.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/script/CollaboraConfigurationScriptService.java
@@ -17,38 +17,44 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package com.xwiki.collabora.configuration;
+package com.xwiki.collabora.script;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
-import org.xwiki.component.annotation.Role;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.script.service.ScriptService;
 import org.xwiki.stability.Unstable;
 
+import com.xwiki.collabora.configuration.CollaboraConfiguration;
+
 /**
- * Collabora configurations.
+ * Script services to access the Collabora configurations.
  *
  * @version $Id$
- * @since 1.0
+ * @since 1.1
  */
-@Role
+@Component
+@Named("collaboraConfiguration")
+@Singleton
 @Unstable
-public interface CollaboraConfiguration
+public class CollaboraConfigurationScriptService implements ScriptService
 {
-    /**
-     * Get the discovery URL, needed for accessing the urlSrc specific to each file format. This is available at
-     * https://WOPIClientURL:port/hosting/discovery.
-     *
-     * @return the discovery {@link URL}
-     * @throws MalformedURLException In case an error occurred while creating the {@link URL}
-     */
-    URL getDiscoveryURL() throws MalformedURLException;
+    @Inject
+    private CollaboraConfiguration configuration;
 
     /**
      * Check if Collabora is enabled. Fallback on the main wiki configuration in case it was not defined at the wiki
      * level.
      *
-     * @return {@code true} if Collabora is enabled, {@code false} if not, and {@code null} when no value is defined
+     * @return {@code true} if Collabora is enabled, {@code false} otherwise
+     * @since 1.1
      */
-    Boolean isEnabled();
+    @Unstable
+    public boolean isEnabled()
+    {
+        Boolean isEnabled = this.configuration.isEnabled();
+        return isEnabled != null ? isEnabled : false;
+    }
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/script/CollaboraScriptService.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/script/CollaboraScriptService.java
@@ -30,31 +30,27 @@ import org.xwiki.stability.Unstable;
 import com.xwiki.collabora.configuration.CollaboraConfiguration;
 
 /**
- * Script services to access the Collabora configurations.
+ * Collabora script services.
  *
  * @version $Id$
  * @since 1.1
  */
 @Component
-@Named("collaboraConfiguration")
+@Named("collabora")
 @Singleton
 @Unstable
-public class CollaboraConfigurationScriptService implements ScriptService
+public class CollaboraScriptService implements ScriptService
 {
     @Inject
     private CollaboraConfiguration configuration;
 
     /**
-     * Check if Collabora is enabled. Fallback on the main wiki configuration in case it was not defined at the wiki
-     * level.
-     *
-     * @return {@code true} if Collabora is enabled, {@code false} otherwise
+     * @return the Collabora configuration
      * @since 1.1
      */
     @Unstable
-    public boolean isEnabled()
+    public CollaboraConfiguration getConfiguration()
     {
-        Boolean isEnabled = this.configuration.isEnabled();
-        return isEnabled != null ? isEnabled : false;
+        return configuration;
     }
 }

--- a/application-collabora-default/src/main/resources/META-INF/components.txt
+++ b/application-collabora-default/src/main/resources/META-INF/components.txt
@@ -5,4 +5,4 @@ com.xwiki.collabora.internal.DiscoveryManager
 com.xwiki.collabora.internal.configuration.CollaboraConfigurationSource
 com.xwiki.collabora.internal.configuration.MainCollaboraConfigurationSource
 com.xwiki.collabora.internal.configuration.DefaultCollaboraConfiguration
-com.xwiki.collabora.script.CollaboraConfigurationScriptService
+com.xwiki.collabora.script.CollaboraScriptService

--- a/application-collabora-default/src/main/resources/META-INF/components.txt
+++ b/application-collabora-default/src/main/resources/META-INF/components.txt
@@ -5,3 +5,4 @@ com.xwiki.collabora.internal.DiscoveryManager
 com.xwiki.collabora.internal.configuration.CollaboraConfigurationSource
 com.xwiki.collabora.internal.configuration.MainCollaboraConfigurationSource
 com.xwiki.collabora.internal.configuration.DefaultCollaboraConfiguration
+com.xwiki.collabora.script.CollaboraConfigurationScriptService

--- a/application-collabora-default/src/main/resources/META-INF/components.txt
+++ b/application-collabora-default/src/main/resources/META-INF/components.txt
@@ -3,4 +3,5 @@ com.xwiki.collabora.internal.FileTokenManager
 com.xwiki.collabora.internal.AttachmentManager
 com.xwiki.collabora.internal.DiscoveryManager
 com.xwiki.collabora.internal.configuration.CollaboraConfigurationSource
+com.xwiki.collabora.internal.configuration.MainCollaboraConfigurationSource
 com.xwiki.collabora.internal.configuration.DefaultCollaboraConfiguration

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -40,9 +40,9 @@
 admin.collabora=Collabora
 admin.collabora.description=Configure Collabora Connector Application
 Collabora.Code.ConfigurationClass_isEnabled=Enable
-Collabora.Code.ConfigurationClass_isEnabled.hint=Enable the possibility to edit page attachments using Collabora Online.
+Collabora.Code.ConfigurationClass_isEnabled.hint=Enable the possibility to edit page attachments using Collabora Online. The main wiki configuration will be used if not set at subwiki level.
 Collabora.Code.ConfigurationClass_server=Server
-Collabora.Code.ConfigurationClass_server.hint=Collabora Online server address
+Collabora.Code.ConfigurationClass_server.hint=Collabora Online server address. The main wiki configuration will be used if not set at subwiki level.
 
 ## Attachments tab
 collabora.attachment.edit.title=Edit using Collabora

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -622,7 +622,7 @@
 
 {{velocity}}
 #if ($xcontext.action == 'view')
-  #if ($services.collaboraConfiguration.isEnabled())
+  #if ($services.collabora.getConfiguration().isEnabled())
     #set ($discard = $xwiki.ssx.use('Collabora.Code.UI'))
     #set ($discard = $xwiki.jsx.use('Collabora.Code.UI'))
     ## Starting with XWiki 14.6 the attachments actions are displayed in a livetable, and later, starting with 14.8,

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -618,13 +618,29 @@
     &lt;/div&gt;
   &lt;/div&gt;
 #end
+#macro (checkIfEnabled $isEnabled)
+  ## Current Wiki configuration.
+  #set ($configDoc = $xwiki.getDocument(
+    $services.model.createDocumentReference($services.wiki.currentWikiId, ['Collabora', 'Code'], 'Configuration')))
+  #set ($configObj = $configDoc.getObject('Collabora.Code.ConfigurationClass'))
+  ## Main wiki configuration.
+  #set ($mainConfigDoc = $xwiki.getDocument(
+    $services.model.createDocumentReference($services.wiki.mainWikiId, ['Collabora', 'Code'], 'Configuration')))
+  #set ($mainConfigObj = $mainConfigDoc.getObject('Collabora.Code.ConfigurationClass'))
+  ## If no value is set for this wiki, then the main wiki configuration is used.
+  #set ($isEnabled = false)
+  #if ($configObj.getValue('isEnabled'))
+    #set ($isEnabled = $configObj.getValue('isEnabled').equals(1))
+  #elseif ($mainConfigObj.getValue('isEnabled'))
+    #set ($isEnabled = $mainConfigObj.getValue('isEnabled').equals(1))
+  #end
+#end
 {{/velocity}}
 
 {{velocity}}
 #if ($xcontext.action == 'view')
-  #set ($configDoc = $xwiki.getDocument('Collabora.Code.Configuration'))
-  #set ($configObj = $configDoc.getObject('Collabora.Code.ConfigurationClass'))
-  #if ($configObj.getValue('isEnabled').equals(1))
+  #checkIfEnabled($isEnabled)
+  #if ($isEnabled)
     #set ($discard = $xwiki.ssx.use('Collabora.Code.UI'))
     #set ($discard = $xwiki.jsx.use('Collabora.Code.UI'))
     ## Starting with XWiki 14.6 the attachments actions are displayed in a livetable, and later, starting with 14.8,

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -618,29 +618,11 @@
     &lt;/div&gt;
   &lt;/div&gt;
 #end
-#macro (checkIfEnabled $isEnabled)
-  ## Current Wiki configuration.
-  #set ($configDoc = $xwiki.getDocument(
-    $services.model.createDocumentReference($services.wiki.currentWikiId, ['Collabora', 'Code'], 'Configuration')))
-  #set ($configObj = $configDoc.getObject('Collabora.Code.ConfigurationClass'))
-  ## Main wiki configuration.
-  #set ($mainConfigDoc = $xwiki.getDocument(
-    $services.model.createDocumentReference($services.wiki.mainWikiId, ['Collabora', 'Code'], 'Configuration')))
-  #set ($mainConfigObj = $mainConfigDoc.getObject('Collabora.Code.ConfigurationClass'))
-  ## If no value is set for this wiki, then the main wiki configuration is used.
-  #set ($isEnabled = false)
-  #if ($configObj.getValue('isEnabled'))
-    #set ($isEnabled = $configObj.getValue('isEnabled').equals(1))
-  #elseif ($mainConfigObj.getValue('isEnabled'))
-    #set ($isEnabled = $mainConfigObj.getValue('isEnabled').equals(1))
-  #end
-#end
 {{/velocity}}
 
 {{velocity}}
 #if ($xcontext.action == 'view')
-  #checkIfEnabled($isEnabled)
-  #if ($isEnabled)
+  #if ($services.collaboraConfiguration.isEnabled())
     #set ($discard = $xwiki.ssx.use('Collabora.Code.UI'))
     #set ($discard = $xwiki.jsx.use('Collabora.Code.UI'))
     ## Starting with XWiki 14.6 the attachments actions are displayed in a livetable, and later, starting with 14.8,


### PR DESCRIPTION
* for server add a ConfigurationSource corresponding to the main wiki, in order to access its defined server when the current wiki does not have a value
* for isEnabled, fallback to the main wiki value when the current wiki does not have one
* modify translations to specify that the main wiki values are used as fallback