### PR TITLE
Make Collabora server usable on subwikis after adding the main wiki as an accepted domain #7

### DIFF
--- a/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/configuration/CollaboraConfiguration.java
@@ -61,4 +61,14 @@ public interface CollaboraConfiguration
      * @since 1.1
      */
     String getServerURL();
+
+    /**
+     * For editing files with Collabora, the domain from where this is done must be declared in the Collabora Online
+     * server configurations. To avoid adding each subwiki domain in the configuration, the main wiki can be used as an
+     * editing endpoint.
+     *
+     * @return {@code true} if the main wiki will be used for editing files, {@code false} if the current wiki will be
+     *     used
+     */
+    boolean editUsingMainWiki();
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -42,6 +42,8 @@ import com.xwiki.collabora.configuration.CollaboraConfiguration;
 @Singleton
 public class DefaultCollaboraConfiguration implements CollaboraConfiguration
 {
+    private static final String EDIT_USING_MAIN_WIKI = "editUsingMainWiki";
+
     private static final String IS_ENABLED = "isEnabled";
 
     private static final String SERVER = "server";
@@ -73,5 +75,13 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     {
         String currentWikiServer = this.currentConfiguration.getProperty(SERVER);
         return StringUtils.isEmpty(currentWikiServer) ? this.mainConfiguration.getProperty(SERVER) : currentWikiServer;
+    }
+
+    @Override
+    public boolean editUsingMainWiki()
+    {
+        Boolean editUsingMainWiki = this.currentConfiguration.getProperty(EDIT_USING_MAIN_WIKI, Boolean.class);
+        return editUsingMainWiki == null ? this.mainConfiguration.getProperty(EDIT_USING_MAIN_WIKI, false)
+            : editUsingMainWiki;
     }
 }

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Configuration.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Configuration.xml
@@ -51,6 +51,15 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <editUsingMainWiki>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <name>editUsingMainWiki</name>
+        <number>3</number>
+        <prettyName>editUsingMainWiki</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </editUsingMainWiki>
       <isEnabled>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -70,6 +79,9 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </server>
     </class>
+    <property>
+      <editUsingMainWiki/>
+    </property>
     <property>
       <isEnabled/>
     </property>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/ConfigurationClass.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/ConfigurationClass.xml
@@ -46,6 +46,15 @@
     <defaultWeb/>
     <nameField/>
     <validationScript/>
+    <editUsingMainWiki>
+      <disabled>0</disabled>
+      <displayFormType>select</displayFormType>
+      <name>editUsingMainWiki</name>
+      <number>3</number>
+      <prettyName>editUsingMainWiki</prettyName>
+      <unmodifiable>0</unmodifiable>
+      <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+    </editUsingMainWiki>
     <isEnabled>
       <disabled>0</disabled>
       <displayFormType>select</displayFormType>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -65,8 +65,8 @@
   ## Save action is included in Collabora editor.
   &lt;div class="actionMenu"&gt;
     &lt;div&gt;
-      #set ($homePageRef = $services.model.createDocumentReference($fileDoc.wiki, 'Main', 'WebHome'))
-      &lt;a href="${xwiki.getDocument($homePageRef).getURL()}" class='homePage'
+      #set ($homePageRef = $services.wiki.getById($fileDoc.wiki).getMainPageReference())
+      &lt;a href="${xwiki.getURL($homePageRef)}" class='homePage'
         title=$escapetool.xml($services.localization.render('core.menu.type.home'))&gt;
         &lt;img src="$xwiki.getSkinFile('logo.svg')"&gt;
       &lt;/a&gt;
@@ -87,9 +87,9 @@
       &lt;/a&gt;
     &lt;/div&gt;
   &lt;/div&gt;
-  #set ($mainWikiPage = $xwiki.getDocument(
+  #set ($mainWikiPageRef = $xwiki.getDocument(
     $services.model.createDocumentReference($services.wiki.mainWikiId, ['Collabora', 'Code'], 'Main')))
-  #if ($services.collabora.getConfiguration().editUsingMainWiki() &amp;&amp; !$xwiki.exists($mainWikiPage))
+  #if ($services.collabora.getConfiguration().editUsingMainWiki() &amp;&amp; !$xwiki.exists($mainWikiPageRef))
     #warning($escapetool.xml($services.localization.render('collabora.validation.notInstalled')))
   #end
   ## Information needed by collabora to be able to edit the current file.

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -65,7 +65,8 @@
   ## Save action is included in Collabora editor.
   &lt;div class="actionMenu"&gt;
     &lt;div&gt;
-      &lt;a href="${xwiki.getURL('Main.WebHome')}" class='homePage'
+      #set ($homePageRef = $services.model.createDocumentReference($fileDoc.wiki, 'Main', 'WebHome'))
+      &lt;a href="${xwiki.getDocument($homePageRef).getURL()}" class='homePage'
         title=$escapetool.xml($services.localization.render('core.menu.type.home'))&gt;
         &lt;img src="$xwiki.getSkinFile('logo.svg')"&gt;
       &lt;/a&gt;
@@ -86,6 +87,11 @@
       &lt;/a&gt;
     &lt;/div&gt;
   &lt;/div&gt;
+  #set ($mainWikiPage = $xwiki.getDocument(
+    $services.model.createDocumentReference($services.wiki.mainWikiId, ['Collabora', 'Code'], 'Main')))
+  #if ($services.collabora.getConfiguration().editUsingMainWiki() &amp;&amp; !$xwiki.exists($mainWikiPage))
+    #warning($escapetool.xml($services.localization.render('collabora.validation.notInstalled')))
+  #end
   ## Information needed by collabora to be able to edit the current file.
   #set ($fileId = $escapetool.xml($services.model.serialize($attachment.getReference(), 'default')))
   #set ($errorMessage = $escapetool.xml($services.localization.render('collabora.editor.error')))

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -43,7 +43,8 @@ Collabora.Code.ConfigurationClass_isEnabled=Enable
 Collabora.Code.ConfigurationClass_isEnabled.hint=Enable the possibility to edit page attachments using Collabora Online. The main wiki configuration will be used if not set at subwiki level.
 Collabora.Code.ConfigurationClass_server=Server
 Collabora.Code.ConfigurationClass_server.hint=Collabora Online server address. The main wiki configuration will be used if not set at subwiki level.
-
+Collabora.Code.ConfigurationClass_editUsingMainWiki=Edit using main wiki
+Collabora.Code.ConfigurationClass_editUsingMainWiki.hint=Use the main wiki domain when editing files, in order to not add each subwiki domain to the docker hosts configuration of Collabora server. The main wiki configuration will be used if not set at subwiki level.
 ## Attachments tab
 collabora.attachment.edit.title=Edit using Collabora
 collabora.attachment.modal.title=Create new file using Collabora
@@ -72,7 +73,8 @@ collabora.editor.unsaved.label=Unsaved changes
 collabora.editor.unsaved.submit=Close without saving
 collabora.validation.attachmentMissing=Document or attachment not found!
 collabora.validation.documentMissing=Document parameter required!
-collabora.validation.filenameMissing=Filename parameter required!</content>
+collabora.validation.filenameMissing=Filename parameter required!
+collabora.validation.notInstalled=Edit is using the current wiki domain, which might not be added to the docker hosts configuration, since Collabora is not installed on the selected main wiki. Please install it or change the configuration in order to always use the current wiki for edit.</content>
   <object>
     <name>Collabora.Code.Translations</name>
     <number>0</number>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -74,7 +74,7 @@ collabora.editor.unsaved.submit=Close without saving
 collabora.validation.attachmentMissing=Document or attachment not found!
 collabora.validation.documentMissing=Document parameter required!
 collabora.validation.filenameMissing=Filename parameter required!
-collabora.validation.notInstalled=Edit is using the current wiki domain, which might not be added to the docker hosts configuration, since Collabora is not installed on the selected main wiki. Please install it or change the configuration in order to always use the current wiki for edit.</content>
+collabora.validation.notInstalled=Collabora Application is not installed on the main wiki so we fall back using the current wiki domain for editing, which might not work if the docker hosts configuration doesn't include the subwiki domain. Either install Collabora on the main wiki or change the configuration to always use the current wiki for edit.</content>
   <object>
     <name>Collabora.Code.Translations</name>
     <number>0</number>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -178,15 +178,16 @@ require(['jquery', 'xwiki-l10n!collabora-attachment'],function($, l10n) {
     return accessRights;
   };
 
-  var getActionURL = function(fileName, accessRights, pageURL) {
+  var getActionURL = function(fileName, accessRights, editURL) {
     const queryString = $.param({
       'document': XWiki.Document.currentDocumentReference.toString(),
       'filename': fileName,
       'action': accessRights,
       'xpage': 'plain'
     });
+    editURL += (editURL.indexOf('?') &lt; 0 ? '?' : '&amp;') + queryString;
 
-    return pageURL + '?' + queryString;
+    return editURL;
   };
 
   var getCollaboraButton = function(thisButton, fileName, accessRights) {
@@ -194,7 +195,7 @@ require(['jquery', 'xwiki-l10n!collabora-attachment'],function($, l10n) {
     thisButton.attr('title', title);
     thisButton.find('img').attr('alt', title);
 
-    thisButton.attr('href', getActionURL(fileName, accessRights, thisButton.data('pageUrl')));
+    thisButton.attr('href', getActionURL(fileName, accessRights, thisButton.data('editUrl')));
     return thisButton;
   };
 

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -169,8 +169,7 @@
     return accessRights;
   };
 
-  var getActionURL = function(fileName, accessRights) {
-    const actionDoc = new XWiki.Document(XWiki.Model.resolve('Collabora.Code.Main', XWiki.EntityType.DOCUMENT));
+  var getActionURL = function(fileName, accessRights, pageURL) {
     const queryString = $.param({
       'document': XWiki.Document.currentDocumentReference.toString(),
       'filename': fileName,
@@ -178,7 +177,7 @@
       'xpage': 'plain'
     });
 
-    return actionDoc.getURL('get', queryString);
+    return pageURL + '?' + queryString;
   };
 
   var getCollaboraButton = function(thisButton, fileName, accessRights) {
@@ -191,7 +190,7 @@
     thisButton.removeAttr('data-edit-title');
     thisButton.removeAttr('data-view-title');
 
-    thisButton.attr('href', getActionURL(fileName, accessRights));
+    thisButton.attr('href', getActionURL(fileName, accessRights, thisButton.data('pageUrl')));
     return thisButton;
   };
 
@@ -237,6 +236,7 @@
     const form = $(this).parents('.modal-content').find('form');
     const formData = new FormData(form[0]);
     const fileName = formData.get('fileName') + formData.get('fileType');
+    const pageURL = $(e.currentTarget).data('pageUrl');
     // TODO: The translation is added for now as a data attribute. This should be changed once the application starts
     // depending on a XWiki version &gt;= 13.8 to include XWIKI-18973: Simplify the way JavaScript code loads
     // translation messages.
@@ -256,7 +256,7 @@
           url: attachURL,
           type: "PUT",
         }).done(function () {
-          window.location = getActionURL(fileName, getAccessRights(fileName, canDoByExt));
+          window.location = getActionURL(fileName, getAccessRights(fileName, canDoByExt), pageURL);
         });
       });
   });
@@ -535,14 +535,29 @@
     </property>
     <property>
       <content>{{velocity output="false"}}
+#macro (getPageEditURL $pageEditURL)
+  #set ($editWiki = $services.wiki.currentWikiId)
+  #if ($services.collabora.getConfiguration().editUsingMainWiki())
+    #set ($editWiki = $services.wiki.mainWikiId)
+  #end
+  #set ($pageEditRef = $services.model.createDocumentReference($editWiki, ['Collabora', 'Code'], 'Main'))
+  ## In case the main wiki was selected as edit endpoint, but the application is not installed on it, fallback on the
+  ## current wiki as endpoint.
+  #if (!$xwiki.exists($pageEditRef))
+    #set ($pageEditRef = $services.model.createDocumentReference($currentWikiId, ['Collabora', 'Code'], 'Main'))
+  #end
+  #set ($pageEditURL = $xwiki.getDocument($pageEditRef).getURL('get'))
+#end
 #macro (tableButtonTemplate)
   #set ($logoURL = $xwiki.getDocument('Collabora.Code.UI').getAttachmentURL('collabora-symbol.svg'))
   #set ($editTitle = $escapetool.xml($services.localization.render("collabora.attachment.edit.title")))
   #set ($viewTitle = $escapetool.xml($services.localization.render("collabora.attachment.view.title")))
   #set ($label = $escapetool.xml($services.localization.render("collabora.attachment.title")))
+  #getPageEditURL($pageEditURL)
   ## After the application starts depending on a version of XWiki &gt;= 14.6, this code should be moved inside an
   ## org.xwiki.platform.attachment.actions UIX.
-  &lt;a class="action collaboraEdit" href="" data-edit-title="$editTitle" data-view-title="$viewTitle"&gt;
+  &lt;a class="action collaboraEdit" href="" data-edit-title="$editTitle" data-view-title="$viewTitle"
+    data-page-url="$pageEditURL"&gt;
     &lt;span class="action-icon"&gt;&lt;img src="$logoURL"/&gt;&lt;/span&gt;
     &lt;span class="action-label"&gt;$label&lt;/span&gt;
   &lt;/a&gt;
@@ -552,8 +567,9 @@
   #set ($editTitle = $escapetool.xml($services.localization.render("collabora.attachment.edit.title")))
   #set ($viewTitle = $escapetool.xml($services.localization.render("collabora.attachment.view.title")))
   #set ($label = $escapetool.xml($services.localization.render("collabora.attachment.title")))
+  #getPageEditURL($pageEditURL)
   &lt;a class="collaboraEdit btn btn-xs btn-default" href="" data-edit-title="$editTitle"
-    data-view-title="$viewTitle"&gt;&lt;img src="$logoURL" /&gt;&lt;/a&gt;
+    data-view-title="$viewTitle" data-page-url="$pageEditURL"&gt;&lt;img src="$logoURL" /&gt;&lt;/a&gt;
 #end
 #macro (createButtonTemplate)
   #set ($logoURL = $xwiki.getDocument('Collabora.Code.UI').getAttachmentURL('collabora-symbol.svg'))
@@ -608,9 +624,11 @@
           #newFileForm()
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
+          #getPageEditURL($pageEditURL)
           &lt;input type="submit" class="btn btn-primary" disabled
             value="$escapetool.xml($services.localization.render('collabora.attachment.modal.submit'))"
-            data-error="$escapetool.xml($services.localization.render("collabora.attachment.modal.submit.error"))"&gt;
+            data-error="$escapetool.xml($services.localization.render("collabora.attachment.modal.submit.error"))"
+            data-page-url="$pageEditURL"&gt;
           &lt;input type="button" class="btn btn-default" data-dismiss="modal"
             value="$escapetool.xml($services.localization.render('cancel'))"&gt;
         &lt;/div&gt;

--- a/application-collabora-ui/src/main/resources/Collabora/WebHome.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/WebHome.xml
@@ -92,6 +92,7 @@ SSL is enabled by default for the Collabora Online server, so this should be the
 === Additional info ===
 
 1. If the Collabora Online server is used from a different domain then it's own, this should be added to the docker hosts configuration for the edit to work. Check their [[documentation&gt;&gt;https://sdk.collaboraonline.com/docs/installation/Configuration.html#multihost-configuration]].
+1. In order to not add each subwiki to the docker hosts configuration, use the //editUsingMainWiki// from the [[XWiki configuration&gt;&gt;XWiki.XWikiPreferences||queryString="editor=globaladmin&amp;section=Collabora"]]. This will start the edit using the main wiki domain, so only this one needs to be declared on the Collabora Server configuration.
 1. There should be no HTTP protection on ///xwiki/rest/collabora/// on the front end.
 1. The Collabora Online server needs to be able to contact the XWiki server using HTTP/HTTPS.
 


### PR DESCRIPTION
* add config option to select if the main wiki domain should be used when editing
* update code to use the main wiki domain when needed, or fallback to the current one in case Collabora is not installed on main