### PR TITLE
Upgrade parent version to 13.10 #20

### DIFF
--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/CollaboraConfigurationSource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/CollaboraConfigurationSource.java
@@ -20,11 +20,10 @@
 package com.xwiki.collabora.internal.configuration;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
-
-import groovy.lang.Singleton;
 
 /**
  * Collabora configuration source corresponding to the current wiki.

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/MainCollaboraConfigurationSource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/MainCollaboraConfigurationSource.java
@@ -21,13 +21,12 @@ package com.xwiki.collabora.internal.configuration;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
-
-import groovy.lang.Singleton;
 
 /**
  * Collabora configuration source corresponding to the main wiki.

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Configuration.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Configuration.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="Collabora.Code.Configuration" locale="">
+<xwikidoc version="1.4" reference="Collabora.Code.Configuration" locale="">
   <web>Collabora.Code</web>
   <name>Configuration</name>
   <language/>
@@ -94,6 +94,7 @@
       <categoryIcon>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>categoryIcon</name>
         <number>11</number>
         <picker>0</picker>
@@ -105,9 +106,11 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </categoryIcon>
       <codeToExecute>
+        <contenttype>VelocityWiki</contenttype>
         <customDisplay/>
         <disabled>0</disabled>
-        <editor>Text</editor>
+        <editor>---</editor>
+        <hint/>
         <name>codeToExecute</name>
         <number>7</number>
         <picker>0</picker>
@@ -123,10 +126,13 @@
         <cache>0</cache>
         <classname/>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
         <displayType>input</displayType>
+        <freeText/>
         <hint/>
         <idField/>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>configurationClass</name>
         <number>3</number>
@@ -144,23 +150,10 @@
         <valueField/>
         <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </configurationClass>
-      <configureGlobally>
-        <customDisplay/>
-        <defaultValue/>
-        <disabled>0</disabled>
-        <displayFormType>checkbox</displayFormType>
-        <displayType/>
-        <name>configureGlobally</name>
-        <number>4</number>
-        <prettyName>configureGlobally</prettyName>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
-      </configureGlobally>
       <displayBeforeCategory>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>displayBeforeCategory</name>
         <number>10</number>
         <picker>0</picker>
@@ -174,6 +167,7 @@
       <displayInCategory>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>displayInCategory</name>
         <number>9</number>
         <picker>0</picker>
@@ -187,6 +181,7 @@
       <displayInSection>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>displayInSection</name>
         <number>1</number>
         <picker>0</picker>
@@ -200,6 +195,7 @@
       <heading>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>heading</name>
         <number>2</number>
         <picker>0</picker>
@@ -213,6 +209,7 @@
       <iconAttachment>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>iconAttachment</name>
         <number>8</number>
         <picker>0</picker>
@@ -226,6 +223,7 @@
       <linkPrefix>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>linkPrefix</name>
         <number>5</number>
         <picker>0</picker>
@@ -239,8 +237,12 @@
       <propertiesToShow>
         <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
         <displayType>input</displayType>
+        <freeText/>
+        <hint/>
+        <largeStorage>0</largeStorage>
         <multiSelect>1</multiSelect>
         <name>propertiesToShow</name>
         <number>6</number>
@@ -257,9 +259,35 @@
         <values/>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </propertiesToShow>
+      <scope>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText/>
+        <hint/>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>12</number>
+        <picker>1</picker>
+        <prettyName>scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>WIKI|SPACE|ALL_SPACES|WIKI+ALL_SPACES</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
       <sectionOrder>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>sectionOrder</name>
         <number>12</number>
         <numberType>integer</numberType>
@@ -281,9 +309,6 @@
       <configurationClass>Collabora.Code.ConfigurationClass</configurationClass>
     </property>
     <property>
-      <configureGlobally>1</configureGlobally>
-    </property>
-    <property>
       <displayBeforeCategory/>
     </property>
     <property>
@@ -303,6 +328,9 @@
     </property>
     <property>
       <propertiesToShow/>
+    </property>
+    <property>
+      <scope>WIKI</scope>
     </property>
     <property>
       <sectionOrder/>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/ConfigurationClass.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/ConfigurationClass.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="Collabora.Code.ConfigurationClass" locale="">
+<xwikidoc version="1.4" reference="Collabora.Code.ConfigurationClass" locale="">
   <web>Collabora.Code</web>
   <name>ConfigurationClass</name>
   <language/>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -88,8 +88,7 @@
   &lt;/div&gt;
   ## Information needed by collabora to be able to edit the current file.
   #set ($fileId = $escapetool.xml($services.model.serialize($attachment.getReference(), 'default')))
-  #set ($errorMessage = $escapetool.xml($services.localization.render('collabora.editor.error')))
-  &lt;span id="collaboraServer" data-file-id="$fileId" data-mode="$mode" data-error="$errorMessage"
+  &lt;span id="collaboraServer" data-file-id="$fileId" data-mode="$mode"
     data-server="$services.collabora.getConfiguration().getServerURL()"&gt;&lt;/span&gt;
   &lt;form class="hidden" action="" enctype="multipart/form-data" method="post" target="collaboraViewer"
     id="collaboraForm"&gt;
@@ -224,7 +223,14 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'], function($) {
+      <code>define('collabora-editor', {
+  prefix: 'collabora.editor.',
+  keys: [
+    'error'
+  ]
+});
+
+require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
   const collaboraPath ='/rest/collabora/files/';
   const iframeWindow = document.getElementById('collaboraViewer').contentWindow;
   var isDocModified = false;
@@ -252,10 +258,6 @@
   $(function() {
     const fileId = $("#collaboraServer").data('fileId');
     const userCanWrite = $("#collaboraServer").data('mode') === 'edit';
-    // TODO: The translation is added for now as a data attribute. This should be changed once the application starts
-    // depending on a XWiki version &gt;= 13.8 to include XWIKI-18973: Simplify the way JavaScript code loads
-    // translation messages. The error cause should also be included in the translation.
-    const errorMessage = $("#collaboraServer").data('error');
     const wopiResourceURL = window.location.origin + '/xwiki' + collaboraPath + encodeURIComponent(fileId);
     const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token';
     $.getJSON(tokenURL).done(function(resp) {
@@ -269,7 +271,7 @@
       $('#collaboraForm input[name=access_token]').attr('value', accessToken);
       $('#collaboraForm').submit();
     }).fail(function(jqxhr, textStatus, error) {
-      new XWiki.widgets.Notification(errorMessage + error, 'error');
+      new XWiki.widgets.Notification(l10n.get('error', error), 'error');
     });
 
     // Listen to messages send by the Collabora editor iframe.

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -61,7 +61,7 @@ collabora.attachment.view.title=View using Collabora
 
 ## Editor
 collabora.editor.onPage=on page
-collabora.editor.error=Error while loading this file. Cause: 
+collabora.editor.error=Error while loading this file. Cause: {0}
 collabora.editor.close=Close
 collabora.editor.close.hint=Close editor
 collabora.editor.file.home.title=File home page

--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -134,7 +134,16 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'],function($) {
+      <code>define('collabora-attachment', {
+  prefix: 'collabora.attachment.',
+  keys: [
+    'edit.title',
+    'view.title',
+    'modal.submit.error'
+  ]
+});
+
+require(['jquery', 'xwiki-l10n!collabora-attachment'],function($, l10n) {
   var getExtAcceptedAction = function() {
     const canDoByExt = {};
     ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'csv', 'rtf', 'txt', 'odt', 'ods', 'odp', 'odg'].forEach(function(x) {
@@ -182,14 +191,9 @@
   };
 
   var getCollaboraButton = function(thisButton, fileName, accessRights) {
-    // The data translations attributes are used for updating the title from js, since it depends on the access rights.
-    // This can be changed once licensing starts depending on a XWiki version &gt;= 13.8 to include
-    // XWIKI-18973: Simplify the way JavaScript code loads translation messages.
-    const title = thisButton.data(accessRights == 'edit' ? 'editTitle' : 'viewTitle');
+    const title = l10n.get(accessRights == 'edit' ? 'edit.title' : 'view.title');
     thisButton.attr('title', title);
     thisButton.find('img').attr('alt', title);
-    thisButton.removeAttr('data-edit-title');
-    thisButton.removeAttr('data-view-title');
 
     thisButton.attr('href', getActionURL(fileName, accessRights));
     return thisButton;
@@ -249,7 +253,7 @@
       )).getRestURL() + "/attachments/" + encodeURIComponent(fileName);
     $.get(attachURL)
       .done(function () {
-        new XWiki.widgets.Notification(errorMessage, "error");
+        new XWiki.widgets.Notification(l10n.get('modal.submit.error'), 'error');
       })
       .fail(function () {
         $.ajax({
@@ -537,23 +541,18 @@
       <content>{{velocity output="false"}}
 #macro (tableButtonTemplate)
   #set ($logoURL = $xwiki.getDocument('Collabora.Code.UI').getAttachmentURL('collabora-symbol.svg'))
-  #set ($editTitle = $escapetool.xml($services.localization.render("collabora.attachment.edit.title")))
-  #set ($viewTitle = $escapetool.xml($services.localization.render("collabora.attachment.view.title")))
   #set ($label = $escapetool.xml($services.localization.render("collabora.attachment.title")))
   ## After the application starts depending on a version of XWiki &gt;= 14.6, this code should be moved inside an
   ## org.xwiki.platform.attachment.actions UIX.
-  &lt;a class="action collaboraEdit" href="" data-edit-title="$editTitle" data-view-title="$viewTitle"&gt;
+  &lt;a class="action collaboraEdit" href=""&gt;
     &lt;span class="action-icon"&gt;&lt;img src="$logoURL"/&gt;&lt;/span&gt;
     &lt;span class="action-label"&gt;$label&lt;/span&gt;
   &lt;/a&gt;
 #end
 #macro (listButtonTemplate)
   #set ($logoURL = $xwiki.getDocument('Collabora.Code.UI').getAttachmentURL('collabora-symbol.svg'))
-  #set ($editTitle = $escapetool.xml($services.localization.render("collabora.attachment.edit.title")))
-  #set ($viewTitle = $escapetool.xml($services.localization.render("collabora.attachment.view.title")))
   #set ($label = $escapetool.xml($services.localization.render("collabora.attachment.title")))
-  &lt;a class="collaboraEdit btn btn-xs btn-default" href="" data-edit-title="$editTitle"
-    data-view-title="$viewTitle"&gt;&lt;img src="$logoURL" /&gt;&lt;/a&gt;
+  &lt;a class="collaboraEdit btn btn-xs btn-default" href=""&gt;&lt;img src="$logoURL" /&gt;&lt;/a&gt;
 #end
 #macro (createButtonTemplate)
   #set ($logoURL = $xwiki.getDocument('Collabora.Code.UI').getAttachmentURL('collabora-symbol.svg'))
@@ -609,8 +608,7 @@
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
           &lt;input type="submit" class="btn btn-primary" disabled
-            value="$escapetool.xml($services.localization.render('collabora.attachment.modal.submit'))"
-            data-error="$escapetool.xml($services.localization.render("collabora.attachment.modal.submit.error"))"&gt;
+            value="$escapetool.xml($services.localization.render('collabora.attachment.modal.submit'))"&gt;
           &lt;input type="button" class="btn btn-default" data-dismiss="modal"
             value="$escapetool.xml($services.localization.render('cancel'))"&gt;
         &lt;/div&gt;

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.parent</groupId>
     <artifactId>xwikisas-parent-platform</artifactId>
-    <version>11.10</version>
+    <version>13.10-3</version>
   </parent>
   <groupId>com.xwiki.collabora</groupId>
   <artifactId>application-collabora</artifactId>
@@ -34,7 +34,7 @@
   <name>Collabora Connector Application (Pro) Parent POM</name>
   <description>Collabora Integration using WOPI</description>
   <properties>
-    <licensing.version>1.22</licensing.version>
+    <licensing.version>1.24.1</licensing.version>
   </properties>
   <issueManagement>
     <system>GitHub</system>


### PR DESCRIPTION
* upgrade dependencies
* export pages from 13.10
* use javascript translations, instead of adding attributes from velocity
* update translation to use parameters now that we use l10n from js
* use correct Singleton package
* replace the deprecated configureGlobally with scope WIKI