### PR TITLE
Check token rights

### DIFF
--- a/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
@@ -70,7 +70,7 @@ public interface Wopi extends XWikiRestComponent
 
     /**
      * Update content of a file. This is used by the Collabora Save action. A specific REST model should be used as
-     * response, see {@link #get(String, String, String)}. This should be a PUT method, but the Collabora online server
+     * response, see {@link #get(String, String)}. This should be a PUT method, but the Collabora online server
      * uses a POST verb on the save action.
      *
      * @param fileId id of the file
@@ -90,13 +90,12 @@ public interface Wopi extends XWikiRestComponent
      * particularities).
      *
      * @param fileId id of the file
-     * @param userCanWrite {@code true} if this user has write access, {@code false} otherwise
      * @return information needed by Collabora to load
      * @throws XWikiRestException if an error occurred while getting information
      */
     @GET
     @Path("/token")
-    Token getToken(@PathParam("id") String fileId, @QueryParam("userCanWrite") boolean userCanWrite)
+    Token getToken(@PathParam("id") String fileId)
         throws XWikiRestException;
 
     /**

--- a/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
@@ -49,13 +49,11 @@ public interface Wopi extends XWikiRestComponent
      *
      * @param fileId id of the file
      * @param token {@code String} representation of the authentication token
-     * @param userCanWrite {@code true} if the user has write access, {@code false} otherwise
      * @return information about the requested file
      * @throws XWikiRestException if an error occurred while accessing the file
      */
     @GET
-    Response get(@PathParam("id") String fileId, @QueryParam("access_token") String token,
-        @QueryParam("userCanWrite") String userCanWrite) throws XWikiRestException;
+    Response get(@PathParam("id") String fileId, @QueryParam("access_token") String token) throws XWikiRestException;
 
     /**
      * Get file content.
@@ -92,12 +90,14 @@ public interface Wopi extends XWikiRestComponent
      * particularities).
      *
      * @param fileId id of the file
+     * @param userCanWrite {@code true} if this user has write access, {@code false} otherwise
      * @return information needed by Collabora to load
      * @throws XWikiRestException if an error occurred while getting information
      */
     @GET
     @Path("/token")
-    Token getToken(@PathParam("id") String fileId) throws XWikiRestException;
+    Token getToken(@PathParam("id") String fileId, @QueryParam("userCanWrite") boolean userCanWrite)
+        throws XWikiRestException;
 
     /**
      * Clear saved token for this file. Consider that this user might be editing the file in another window, so don't

--- a/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
@@ -70,8 +70,8 @@ public interface Wopi extends XWikiRestComponent
 
     /**
      * Update content of a file. This is used by the Collabora Save action. A specific REST model should be used as
-     * response, see {@link #get(String, String)}. This should be a PUT method, but the Collabora online server
-     * uses a POST verb on the save action.
+     * response, see {@link #get(String, String)}. This should be a PUT method, but the Collabora online server uses a
+     * POST verb on the save action.
      *
      * @param fileId id of the file
      * @param token {@code String} representation of the authentication token
@@ -95,8 +95,7 @@ public interface Wopi extends XWikiRestComponent
      */
     @GET
     @Path("/token")
-    Token getToken(@PathParam("id") String fileId)
-        throws XWikiRestException;
+    Token getToken(@PathParam("id") String fileId) throws XWikiRestException;
 
     /**
      * Clear saved token for this file. Consider that this user might be editing the file in another window, so don't

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
@@ -43,7 +43,7 @@ public class FileToken
 
     private final int randomNumber;
 
-    private final boolean userCanWrite;
+    private boolean userCanWrite;
 
     private int usage;
 
@@ -118,6 +118,14 @@ public class FileToken
     public boolean getUserCanWrite()
     {
         return this.userCanWrite;
+    }
+
+    /**
+     * @param userCanWrite {@code true} if this token has edit rights, {@code false} otherwise
+     */
+    public void setUserCanWrite(boolean userCanWrite)
+    {
+        this.userCanWrite = userCanWrite;
     }
 
     @Override

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
@@ -43,18 +43,21 @@ public class FileToken
 
     private final int randomNumber;
 
-    private boolean userCanWrite;
+    private boolean hasView;
+
+    private boolean hasEdit;
 
     private int usage;
 
-    FileToken(String user, String fileId, boolean userCanWrite)
+    FileToken(String user, String fileId, boolean hasView, boolean hasEdit)
     {
         this.user = user;
         this.fileId = fileId;
         this.timestamp = new Date().getTime();
         this.randomNumber = Math.abs(SECURE_RANDOM.nextInt());
         this.usage = 1;
-        this.userCanWrite = userCanWrite;
+        this.hasView = hasView;
+        this.hasEdit = hasEdit;
     }
 
     /**
@@ -113,19 +116,35 @@ public class FileToken
     }
 
     /**
-     * @return {@code true} if this token has edit rights, {@code false} otherwise
+     * @return {@code true} if this token has view rights, {@code false} otherwise
      */
-    public boolean getUserCanWrite()
+    public boolean hasView()
     {
-        return this.userCanWrite;
+        return this.hasView;
     }
 
     /**
-     * @param userCanWrite {@code true} if this token has edit rights, {@code false} otherwise
+     * @param hasView {@code true} if this token has view rights, {@code false} otherwise
      */
-    public void setUserCanWrite(boolean userCanWrite)
+    public void setHasView(boolean hasView)
     {
-        this.userCanWrite = userCanWrite;
+        this.hasView = hasView;
+    }
+
+    /**
+     * @return {@code true} if this token has edit rights, {@code false} otherwise
+     */
+    public boolean hasEdit()
+    {
+        return this.hasEdit;
+    }
+
+    /**
+     * @param hasEdit {@code true} if this token has edit rights, {@code false} otherwise
+     */
+    public void setHasEdit(boolean hasEdit)
+    {
+        this.hasEdit = hasEdit;
     }
 
     @Override

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
@@ -43,15 +43,18 @@ public class FileToken
 
     private final int randomNumber;
 
+    private final boolean userCanWrite;
+
     private int usage;
 
-    FileToken(String user, String fileId)
+    FileToken(String user, String fileId, boolean userCanWrite)
     {
         this.user = user;
         this.fileId = fileId;
         this.timestamp = new Date().getTime();
         this.randomNumber = Math.abs(SECURE_RANDOM.nextInt());
         this.usage = 1;
+        this.userCanWrite = userCanWrite;
     }
 
     /**
@@ -107,6 +110,14 @@ public class FileToken
     public Long getTimestamp()
     {
         return this.timestamp;
+    }
+
+    /**
+     * @return {@code true} if this token has edit rights, {@code false} otherwise
+     */
+    public boolean getUserCanWrite()
+    {
+        return this.userCanWrite;
     }
 
     @Override

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
@@ -63,9 +63,10 @@ public class FileTokenManager
      *
      * @param userReference current user reference
      * @param fileId id of the edited file
+     * @param userCanWrite {@code true} if this user has edit right on the document, {@code false otherwise}
      * @return existing {@link FileToken}, or a new one
      */
-    public FileToken getToken(DocumentReference userReference, String fileId)
+    public FileToken getToken(DocumentReference userReference, String fileId, boolean userCanWrite)
     {
         String user = userReference != null ? this.referenceSerializer.serialize(userReference) : XWIKI_GUEST;
         FileToken token = getExistingToken(user, fileId);
@@ -78,7 +79,7 @@ public class FileTokenManager
             }
         }
 
-        return createNewToken(user, fileId);
+        return createNewToken(user, fileId, userCanWrite);
     }
 
     /**
@@ -140,6 +141,15 @@ public class FileTokenManager
         return this.documentReferenceResolver.resolve(fileToken.getUser());
     }
 
+    /**
+     * @param token string representation of the token
+     * @return {@code true} if this token has edit rights, {@code false} otherwise
+     */
+    public boolean hasWriteAccess(String token)
+    {
+        return tokens.get(token).getUserCanWrite();
+    }
+
     private FileToken getExistingToken(String user, String fileId)
     {
         Optional<Map.Entry<String, FileToken>> tokenEntry = this.tokens.entrySet().stream()
@@ -147,9 +157,9 @@ public class FileTokenManager
         return tokenEntry.map(Map.Entry::getValue).orElse(null);
     }
 
-    private FileToken createNewToken(String user, String fileId)
+    private FileToken createNewToken(String user, String fileId, boolean userCanWrite)
     {
-        FileToken token = new FileToken(user, fileId);
+        FileToken token = new FileToken(user, fileId, userCanWrite);
         tokens.put(token.toString(), token);
         logger.debug("New token created for file [{}] and user [{}],", fileId, user);
 

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
@@ -75,6 +75,8 @@ public class FileTokenManager
                 tokens.remove(token.toString());
             } else {
                 token.setUsage(token.getUsage() + 1);
+                // Update token rights in case they have been changed in the meantime.
+                token.setUserCanWrite(userCanWrite);
                 return token;
             }
         }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
@@ -95,7 +95,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     private EntityReferenceSerializer<String> referenceSerializer;
 
     @Override
-    public Response get(String fileId, String token, String userCanWrite) throws XWikiRestException
+    public Response get(String fileId, String token) throws XWikiRestException
     {
         if (token == null || fileTokenManager.isInvalid(token)) {
             logger.warn("Failed to get file [{}] due to invalid token", fileId);
@@ -108,7 +108,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
             JSONObject message = new JSONObject();
             message.put("BaseFileName", attachmentReference.getName());
             message.put("Size", String.valueOf(attachment.getLongSize()));
-            message.put("UserCanWrite", userCanWrite);
+            message.put("UserCanWrite", fileTokenManager.hasWriteAccess(token));
             message.put("UserId", referenceSerializer.serialize(fileTokenManager.getTokenUserDocReference(token)));
             message.put("UserFriendlyName",
                 userManager.getUserFriendlyName(fileTokenManager.getTokenUserDocReference(token)));
@@ -171,7 +171,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     }
 
     @Override
-    public Token getToken(String fileId) throws XWikiRestException
+    public Token getToken(String fileId, boolean userCanWrite) throws XWikiRestException
     {
         XWikiContext xcontext = this.contextProvider.get();
         // Make sure that the current wiki is used on the XWiki context, since the REST resource is rooted on the
@@ -184,7 +184,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
 
             Token token = (new ObjectFactory()).createToken();
             token.setUrlSrc(urlSrc);
-            token.setValue(fileTokenManager.getToken(xcontext.getUserReference(), fileId).toString());
+            token.setValue(fileTokenManager.getToken(xcontext.getUserReference(), fileId, userCanWrite).toString());
 
             return token;
         } catch (IOException e) {

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
@@ -97,8 +97,8 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     @Override
     public Response get(String fileId, String token) throws XWikiRestException
     {
-        if (token == null || fileTokenManager.isInvalid(token)) {
-            logger.warn("Failed to get file [{}] due to invalid token", fileId);
+        if (token == null || fileTokenManager.isInvalid(token) || !fileTokenManager.hasAccess(token)) {
+            logger.warn("Failed to get file [{}] due to invalid token or restricted rights.", fileId);
             throw new WebApplicationException(Response.Status.UNAUTHORIZED);
         }
 
@@ -127,8 +127,8 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     @Override
     public Response getContents(String fileId, String token) throws XWikiRestException
     {
-        if (fileTokenManager.isInvalid(token)) {
-            logger.warn("Failed get content of file [{}] due to invalid token", fileId);
+        if (fileTokenManager.isInvalid(token) || !fileTokenManager.hasAccess(token)) {
+            logger.warn("Failed to get content of file [{}] due to invalid token or restricted rights.", fileId);
             return Response.status(Response.Status.UNAUTHORIZED).build();
         }
 
@@ -149,8 +149,8 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     @Override
     public Response postContents(String fileId, String token, byte[] body) throws XWikiRestException
     {
-        if (fileTokenManager.isInvalid(token)) {
-            logger.warn("Failed to update file [{}] due to invalid token", fileId);
+        if (fileTokenManager.isInvalid(token) || !fileTokenManager.hasAccess(token)) {
+            logger.warn("Failed to update file [{}] due to invalid token or restricted rights.", fileId);
             throw new WebApplicationException(Response.Status.UNAUTHORIZED);
         }
 
@@ -171,7 +171,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
     }
 
     @Override
-    public Token getToken(String fileId, boolean userCanWrite) throws XWikiRestException
+    public Token getToken(String fileId) throws XWikiRestException
     {
         XWikiContext xcontext = this.contextProvider.get();
         // Make sure that the current wiki is used on the XWiki context, since the REST resource is rooted on the
@@ -184,7 +184,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
 
             Token token = (new ObjectFactory()).createToken();
             token.setUrlSrc(urlSrc);
-            token.setValue(fileTokenManager.getToken(xcontext.getUserReference(), fileId, userCanWrite).toString());
+            token.setValue(fileTokenManager.getToken(xcontext.getUserReference(), fileId).toString());
 
             return token;
         } catch (IOException e) {

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -265,10 +265,7 @@ require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
     const fileId = $("#collaboraServer").data('fileId');
     const userCanWrite = $("#collaboraServer").data('mode') === 'edit';
     const wopiResourceURL = window.location.origin + '/xwiki' + collaboraPath + encodeURIComponent(fileId);
-    const params = $.param({
-      userCanWrite: userCanWrite
-    });
-    const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token?' + params;
+    const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token';
     $.getJSON(tokenURL).done(function(resp) {
       const fileUrlSrc = resp.urlSrc;
       const accessToken =  resp.value;

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -265,15 +265,15 @@ require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
     const fileId = $("#collaboraServer").data('fileId');
     const userCanWrite = $("#collaboraServer").data('mode') === 'edit';
     const wopiResourceURL = window.location.origin + '/xwiki' + collaboraPath + encodeURIComponent(fileId);
-    const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token';
+    const params = $.param({
+      userCanWrite: userCanWrite
+    });
+    const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token?' + params;
     $.getJSON(tokenURL).done(function(resp) {
       const fileUrlSrc = resp.urlSrc;
       const accessToken =  resp.value;
-      const params = $.param({
-        userCanWrite: userCanWrite
-      });
       const lang = encodeURIComponent($('html').attr('lang'));
-      const wopiSrc = encodeURIComponent(wopiResourceURL + '?' + params);
+      const wopiSrc = encodeURIComponent(wopiResourceURL);
       const actionURL = fileUrlSrc + 'lang=' + lang + '&amp;WOPISrc=' + wopiSrc;
       $('#collaboraForm').attr('action', actionURL);
       $('#collaboraForm input[name=access_token]').attr('value', accessToken);


### PR DESCRIPTION
* save the rights of a token when this is stored, since you should not need other information besides the token; before, these rights were send on each get request


EDIT, since the above implementation was changed:
* check rights of the current user on the requested file and store them on the token
* make sure that the token rights are up to date when files are requested