### PR TITLE
Display to the user that their Editing Token Timeout has expired #47

### DIFF
--- a/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
@@ -21,6 +21,7 @@ package com.xwiki.collabora.rest;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
@@ -109,4 +110,16 @@ public interface Wopi extends XWikiRestComponent
     @POST
     @Path("/token")
     Token clearToken(@PathParam("id") String fileId) throws XWikiRestException;
+
+    /**
+     * Find a token associated with the given file if and the context user, and if it expired extends the timeout with
+     * the Collabora configuration set value.
+     *
+     * @param fileId id of the file
+     * @return status code of the operation
+     * @throws XWikiRestException if an error occurred while extending the token
+     */
+    @PUT
+    @Path("/token/extend")
+    Response updateTokenExpiration(@PathParam("id") String fileId) throws XWikiRestException;
 }

--- a/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
+++ b/application-collabora-api/src/main/java/com/xwiki/collabora/rest/Wopi.java
@@ -112,8 +112,8 @@ public interface Wopi extends XWikiRestComponent
     Token clearToken(@PathParam("id") String fileId) throws XWikiRestException;
 
     /**
-     * Find a token associated with the given file if and the context user, and if it expired extends the timeout with
-     * the Collabora configuration set value.
+     * If the token for the given file is associated to the current user and has expired, extends the expiration time
+     * of the token. The token's timeout is extended based on the Collabora configuration settings.
      *
      * @param fileId id of the file
      * @return status code of the operation

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileToken.java
@@ -46,7 +46,7 @@ public class FileToken
     /**
      * Token timeout, in seconds.
      */
-    private final int tokenTimeout;
+    private int tokenTimeout;
 
     private boolean hasView;
 
@@ -183,6 +183,16 @@ public class FileToken
         builder.append(this.getRandomNumber(), other.getRandomNumber());
 
         return builder.build();
+    }
+
+    /**
+     * Extends the token timeout with the given amount converted from hours to seconds.
+     *
+     * @param tokenTimeout how many hours to extend the token by.
+     */
+    public void extendTokenTimeout(int tokenTimeout)
+    {
+        this.tokenTimeout += tokenTimeout * 3600;
     }
 
     private int getRandomNumber()

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
@@ -128,12 +128,11 @@ public class FileTokenManager
     }
 
     /**
-     * Checks if a token is associated with the given file id and user and if the user has rights on the file, extends
-     * time out of the token.
+     * Checks if a token is associated with the given file id and user and if the user has rights on the file.
      *
      * @param fileId id of the edited file
      * @param userReference {@link DocumentReference} user reference associated with the checked token
-     * @return {@code true} if the token has been extended, {@code false} otherwise
+     * @return {@code true} if the token can be extended, {@code false} otherwise
      */
     public boolean canExtendToken(String fileId, DocumentReference userReference)
     {
@@ -141,13 +140,24 @@ public class FileTokenManager
         FileToken fileToken = getExistingToken(user, fileId);
         if (fileToken != null) {
             updateAccessRights(fileToken);
-            if (fileToken.hasView() || fileToken.hasEdit()) {
-                fileToken.extendTokenTimeout(configurationProvider.get().getTokenTimeout());
-                return true;
-            }
+            return hasAccess(fileToken.toString());
         }
-
         return false;
+    }
+
+    /**
+     *  Extends token time out.
+     *
+     * @param fileId id of the edited file
+     * @param userReference {@link DocumentReference} user reference associated with the checked token
+     */
+    public void extendToken(String fileId, DocumentReference userReference)
+    {
+        String user = userReference != null ? this.referenceSerializer.serialize(userReference) : XWIKI_GUEST;
+        FileToken fileToken = getExistingToken(user, fileId);
+        if (fileToken != null) {
+            fileToken.extendTokenTimeout(configurationProvider.get().getTokenTimeout());
+        }
     }
 
     /**

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/FileTokenManager.java
@@ -128,25 +128,7 @@ public class FileTokenManager
     }
 
     /**
-     * Checks if a token is associated with the given file id and user and if the user has rights on the file.
-     *
-     * @param fileId id of the edited file
-     * @param userReference {@link DocumentReference} user reference associated with the checked token
-     * @return {@code true} if the token can be extended, {@code false} otherwise
-     */
-    public boolean canExtendToken(String fileId, DocumentReference userReference)
-    {
-        String user = userReference != null ? this.referenceSerializer.serialize(userReference) : XWIKI_GUEST;
-        FileToken fileToken = getExistingToken(user, fileId);
-        if (fileToken != null) {
-            updateAccessRights(fileToken);
-            return hasAccess(fileToken.toString());
-        }
-        return false;
-    }
-
-    /**
-     *  Extends token time out.
+     * Extends token time out with the Collabora configuration value.
      *
      * @param fileId id of the edited file
      * @param userReference {@link DocumentReference} user reference associated with the checked token
@@ -222,7 +204,24 @@ public class FileTokenManager
     public boolean hasAccess(String token)
     {
         FileToken fileToken = tokens.get(token);
+        updateAccessRights(fileToken);
         return fileToken.hasView() || fileToken.hasEdit();
+    }
+
+    /**
+     * @param fileId id of the edited file
+     * @param userReference {@link DocumentReference} user reference associated with the checked token
+     * @return {@code true} if this token has view or edit rights for accessing the file, {@code false} otherwise
+     */
+    public boolean hasAccess(String fileId, DocumentReference userReference)
+    {
+        String user = userReference != null ? this.referenceSerializer.serialize(userReference) : XWIKI_GUEST;
+        FileToken fileToken = getExistingToken(user, fileId);
+        if (fileToken != null) {
+            updateAccessRights(fileToken);
+            return fileToken.hasView() || fileToken.hasEdit();
+        }
+        return false;
     }
 
     /**

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultWopi.java
@@ -217,7 +217,7 @@ public class DefaultWopi extends ModifiablePageResource implements Wopi
         try {
             XWikiContext xcontext = this.contextProvider.get();
             if (fileTokenManager.isInvalid(fileId, xcontext.getUserReference())) {
-                if (fileTokenManager.canExtendToken(fileId, xcontext.getUserReference())) {
+                if (fileTokenManager.hasAccess(fileId, xcontext.getUserReference())) {
                     fileTokenManager.extendToken(fileId, xcontext.getUserReference());
                     return Response.ok().type(MediaType.TEXT_PLAIN_TYPE).build();
                 } else {

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -60,9 +60,9 @@
     &lt;/div&gt;
   &lt;/div&gt;
 #end
-#macro (unauthorizedUserModal)
-  &lt;div class="modal fade" id="unauthorizedUserPopup" tabindex="-1" role="dialog" aria-hidden="true"
-    aria-label="unauthorizedUserPopupLabel"&gt;
+#macro (getUnauthorizedUserModal)
+  &lt;div class="modal fade" id="unauthorizedUserModal" tabindex="-1" role="dialog" aria-hidden="true"
+    aria-label="unauthorizedUserModalLabel"&gt;
     &lt;div class="modal-dialog modal-sm"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-body"&gt;
@@ -120,7 +120,7 @@
   ## Where the document will be displayed.
   &lt;iframe id="collaboraViewer" name="collaboraViewer"&gt;&lt;/iframe&gt;
   #unsavedChangesModal()
-  #unauthorizedUserModal()
+  #getUnauthorizedUserModal()
 #end
 {{/velocity}}
 
@@ -283,14 +283,18 @@ require(['jquery', 'xwiki-l10n!collabora-editor-errors'], function($, l10n) {
     } else if (msg.MessageId == 'Doc_ModifiedStatus') {
       isDocModified = msg.Values &amp;&amp; msg.Values.Modified;
       if (isDocModified == false) {
-        const fileId = $("#collaboraServer").data('fileId');
+        const fileId = $('#collaboraServer').data('fileId');
         const tokenUpdateURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token/extend';
+        // We cannot renew or check the token before the Collabora save action, so we trigger a new request that in
+        // case it's needed, it renews the token before the Collabora token expiration date.
         $.ajax({
           url: tokenUpdateURL,
           type: 'PUT',
           dataType: 'text',
           success: function(resp, textStatus, jqXHR) {
             if (jqXHR.status == 200) {
+              // In case of a successful renewal of a token, a new save request is triggered to ensure that the
+              // content is properly saved.
               iframeWindow.postMessage(
                 JSON.stringify({ 'MessageId': 'Action_Save' }),
                 $("#collaboraServer").data('server')
@@ -299,7 +303,7 @@ require(['jquery', 'xwiki-l10n!collabora-editor-errors'], function($, l10n) {
           },
           error: function(jqxhr, textStatus, error) {
             if (jqxhr.status == 401){
-              $('#unauthorizedUserPopup').modal('show');
+              $('#unauthorizedUserModal').modal('show');
             } else {
               new XWiki.widgets.Notification(l10n.get('internal', error), 'error');
             }
@@ -310,7 +314,7 @@ require(['jquery', 'xwiki-l10n!collabora-editor-errors'], function($, l10n) {
   }
 
   $(function() {
-    const fileId = $("#collaboraServer").data('fileId');
+    const fileId = $('#collaboraServer').data('fileId');
     const userCanWrite = $("#collaboraServer").data('mode') === 'edit';
     const wopiResourceURL = window.location.origin + XWiki.contextPath + collaboraPath + encodeURIComponent(fileId);
     const tokenURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token';

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Main.xml
@@ -60,6 +60,22 @@
     &lt;/div&gt;
   &lt;/div&gt;
 #end
+#macro (unauthorizedUserModal)
+  &lt;div class="modal fade" id="unauthorizedUserPopup" tabindex="-1" role="dialog" aria-hidden="true"
+    aria-label="unauthorizedUserPopupLabel"&gt;
+    &lt;div class="modal-dialog modal-sm"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-body"&gt;
+          $escapetool.xml($services.localization.render('collabora.editor.error.unauthorized'))
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
 #macro (renderCollaboraContent $mode)
   ## Display logo and some information about the currently edited file. Show Close action on the right.
   ## Save action is included in Collabora editor.
@@ -104,6 +120,7 @@
   ## Where the document will be displayed.
   &lt;iframe id="collaboraViewer" name="collaboraViewer"&gt;&lt;/iframe&gt;
   #unsavedChangesModal()
+  #unauthorizedUserModal()
 #end
 {{/velocity}}
 
@@ -234,14 +251,15 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>define('collabora-editor', {
-  prefix: 'collabora.editor.',
+      <code>define('collabora-editor-errors', {
+  prefix: 'collabora.editor.error.',
   keys: [
-    'error'
+    'load',
+    'internal'
   ]
 });
 
-require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
+require(['jquery', 'xwiki-l10n!collabora-editor-errors'], function($, l10n) {
   const collaboraPath ='/rest/collabora/files/';
   const iframeWindow = document.getElementById('collaboraViewer').contentWindow;
   var isDocModified = false;
@@ -264,8 +282,33 @@ require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
       );
     } else if (msg.MessageId == 'Doc_ModifiedStatus') {
       isDocModified = msg.Values &amp;&amp; msg.Values.Modified;
+      if (isDocModified == false) {
+        const fileId = $("#collaboraServer").data('fileId');
+        const tokenUpdateURL = XWiki.contextPath + collaboraPath + encodeURIComponent(fileId) + '/token/extend';
+        $.ajax({
+          url: tokenUpdateURL,
+          type: 'PUT',
+          dataType: 'text',
+          success: function(resp, textStatus, jqXHR) {
+            if (jqXHR.status == 200) {
+              iframeWindow.postMessage(
+                JSON.stringify({ 'MessageId': 'Action_Save' }),
+                $("#collaboraServer").data('server')
+              );
+            }
+          },
+          error: function(jqxhr, textStatus, error) {
+            if (jqxhr.status == 401){
+              $('#unauthorizedUserPopup').modal('show');
+            } else {
+              new XWiki.widgets.Notification(l10n.get('internal', error), 'error');
+            }
+          }
+        });
+      }
     }
   }
+
   $(function() {
     const fileId = $("#collaboraServer").data('fileId');
     const userCanWrite = $("#collaboraServer").data('mode') === 'edit';
@@ -281,7 +324,7 @@ require(['jquery', 'xwiki-l10n!collabora-editor'], function($, l10n) {
       $('#collaboraForm input[name=access_token]').attr('value', encodeURIComponent(accessToken));
       $('#collaboraForm').submit();
     }).fail(function(jqxhr, textStatus, error) {
-      new XWiki.widgets.Notification(l10n.get('error', error), 'error');
+      new XWiki.widgets.Notification(l10n.get('load', error), 'error');
     });
 
     // Listen to messages send by the Collabora editor iframe.

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -67,7 +67,9 @@ collabora.attachment.view.title=View using Collabora
 
 ## Editor
 collabora.editor.onPage=on page
-collabora.editor.error=Error while loading this file. Cause: {0}
+collabora.editor.error.load=Error while loading this file. Cause: {0}
+collabora.editor.error.unauthorized=User is unauthorized to perform this action or token is no longer available.
+collabora.editor.error.internal=Internal error occurred. Cause: {0}
 collabora.editor.close=Close
 collabora.editor.close.hint=Close editor
 collabora.editor.file.home.title=File home page


### PR DESCRIPTION
Modified the message listener to attempt a token extension whenever a save is made by sending a request to an endpoint for extending the timeout of an existing token.