### PR TITLE
Guest appears as the last author of a page after modifying attachments with Collabora connector #43

### DIFF
--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/AttachmentManager.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/AttachmentManager.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -31,6 +32,7 @@ import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rest.XWikiRestException;
+import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -53,6 +55,10 @@ public class AttachmentManager
 
     @Inject
     private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userReferenceResolver;
 
     /**
      * Create or update attachment with given content.
@@ -77,9 +83,10 @@ public class AttachmentManager
                 document.setAttachment(attachmentReference.getName(), new ByteArrayInputStream(content), xcontext);
             attachment.setAuthorReference(userReference);
 
-            document.setAuthorReference(xcontext.getUserReference());
+            document.getAuthors().setOriginalMetadataAuthor(userReferenceResolver.resolve(userReference));
             xwiki.saveDocument(document,
-                this.contextualLocalizationManager.getTranslationPlain("collabora.save.comment"), xcontext);
+                this.contextualLocalizationManager.getTranslationPlain("collabora.save.comment",
+                    attachment.getFilename(), userReference.getName()), xcontext);
 
             return attachment;
         } catch (XWikiException | IOException e) {

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.fr.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.fr.xml
@@ -75,5 +75,6 @@ collabora.editor.unsaved.submit=Fermer sans enregistrer
 collabora.validation.attachmentMissing=La page ou la pièce jointe n'ont pas été trouvées.
 collabora.validation.documentMissing=Le nom de la page est obligatoire!
 collabora.validation.filenameMissing=Le nom du fichier est obligatoire!
-collabora.validation.notInstalled=L''application Collabora n''est pas installée sur le wiki principal, nous utilisons donc le domaine wiki actuel pour l''édition, ce qui peut ne pas fonctionner si la configuration des hôtes docker n''inclut pas le domaine du sous-wiki. Installez Collabora sur le wiki principal ou modifiez la configuration pour toujours utiliser le wiki actuel pour l''édition.</content>
+collabora.validation.notInstalled=L''application Collabora n''est pas installée sur le wiki principal, nous utilisons donc le domaine wiki actuel pour l''édition, ce qui peut ne pas fonctionner si la configuration des hôtes docker n''inclut pas le domaine du sous-wiki. Installez Collabora sur le wiki principal ou modifiez la configuration pour toujours utiliser le wiki actuel pour l''édition.
+collabora.save.comment=Document [{0}] a été actualisé par [{1}].</content>
 </xwikidoc>

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -81,7 +81,8 @@ collabora.editor.unsaved.submit=Close without saving
 collabora.validation.attachmentMissing=Document or attachment not found!
 collabora.validation.documentMissing=Document parameter required!
 collabora.validation.filenameMissing=Filename parameter required!
-collabora.validation.notInstalled=Collabora Application is not installed on the main wiki so we fall back using the current wiki domain for editing, which might not work if the docker hosts configuration doesn't include the subwiki domain. Either install Collabora on the main wiki or change the configuration to always use the current wiki for edit.</content>
+collabora.validation.notInstalled=Collabora Application is not installed on the main wiki so we fall back using the current wiki domain for editing, which might not work if the docker hosts configuration doesn't include the subwiki domain. Either install Collabora on the main wiki or change the configuration to always use the current wiki for edit.
+collabora.save.comment=Document [{0}] has been modified by [{1}].</content>
   <object>
     <name>Collabora.Code.Translations</name>
     <number>0</number>


### PR DESCRIPTION
* added missing translation
* at attachment save, replaced from document save the user reference from context (as it is not available when saving a document), with the one from the existing token
* at attachment save, set only the original metadata author to the token user, without modifying any other author