### PR TITLE
Saving a document does not work on XWiki SAS intranet #61

### DIFF
--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -80,6 +80,6 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     @Override
     public int getTokenTimeout()
     {
-        return this.currentConfiguration.getProperty(TOKEN_TIMEOUT, 5);
+        return this.currentConfiguration.getProperty(TOKEN_TIMEOUT, 48);
     }
 }

--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/configuration/DefaultCollaboraConfiguration.java
@@ -80,6 +80,6 @@ public class DefaultCollaboraConfiguration implements CollaboraConfiguration
     @Override
     public int getTokenTimeout()
     {
-        return this.currentConfiguration.getProperty(TOKEN_TIMEOUT, 0);
+        return this.currentConfiguration.getProperty(TOKEN_TIMEOUT, 5);
     }
 }

--- a/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/Translations.xml
@@ -48,7 +48,7 @@ Collabora.Code.ConfigurationClass_server.hint=Collabora Online server address. T
 Collabora.Code.ConfigurationClass_editUsingMainWiki=Edit using main wiki
 Collabora.Code.ConfigurationClass_editUsingMainWiki.hint=Use the main wiki domain when editing files, in order to not add each subwiki domain to the docker hosts configuration of Collabora server. The main wiki configuration will be used if not set at subwiki level.
 Collabora.Code.ConfigurationClass_tokenTimeout=Editing token timeout
-Collabora.Code.ConfigurationClass_tokenTimeout.hint=The number of hours after which an editing token expires. Note that after expiration, edition will stop working and a refresh is needed. The number of hours should be added (e.g. 1 for 1 hour, 2 for 2 hours). If not set at the subwiki or main wiki level, a default value of 5 is used.
+Collabora.Code.ConfigurationClass_tokenTimeout.hint=The number of hours after which an editing token expires. Note that after expiration, edition will stop working and a refresh is needed. The number of hours should be added (e.g. 1 for 1 hour, 2 for 2 hours). If not set at the subwiki or main wiki level, a default value of 48 is used.
 
 ## Attachments tab
 collabora.attachment.edit.title=Edit using Collabora


### PR DESCRIPTION
Set token default value at 48h and updated translation.