### PR TITLE
Handle Apache Commons Lang 2 dependency issue for XWiki version 17.6.x #83

### DIFF
--- a/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultCollaboraResource.java
+++ b/application-collabora-default/src/main/java/com/xwiki/collabora/internal/rest/DefaultCollaboraResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;


### PR DESCRIPTION
Modified `apache.commons.lang` dependency from version 2 to 3.