### PR TITLE
Race conditions when loading translation keys from collabora-attachment leads to UI breakage #87

### DIFF
--- a/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
+++ b/application-collabora-ui/src/main/resources/Collabora/Code/UI.xml
@@ -847,7 +847,8 @@
     </property>
     <property>
       <parameters>id=collabora-utils
-path=$services.webjars.url('com.xwiki.collabora:application-collabora-webjar', 'collabora-utils.js', {'evaluate': true})</parameters>
+path=$services.webjars.url('com.xwiki.collabora:application-collabora-webjar', 'collabora-utils.js', {'evaluate': true})
+bundles=collabora-attachment</parameters>
     </property>
     <property>
       <scope>wiki</scope>


### PR DESCRIPTION
Added `collabora-attachment` as a bundle to `collabora-utils`.